### PR TITLE
removido campo que reatribuia no controller uma string vazia ao avatar

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -51,13 +51,11 @@ export class UsersController {
   @Roles(Role.ADMIN)
   @UseGuards(RolesGuard)
   async create(@Body() user: User): Promise<User> {
-    user.avatar = '';
     return await this.userService.create(user);
   }
   @IsPublic()
   @Post('public')
   async createpub(@Body() user: UserPub): Promise<User> {
-    user.avatar = '';
     user.role = Role.USER;
     return await this.userService.create(user);
   }


### PR DESCRIPTION
Foi removido a atribuição vazia que existia na requisição dentro do controller e voltou a funcionar